### PR TITLE
Support file exists behavior

### DIFF
--- a/aws-codedeploy-agent/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployRunner.java
+++ b/aws-codedeploy-agent/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployRunner.java
@@ -17,6 +17,7 @@
 package jetbrains.buildServer.runner.codedeploy;
 
 import com.amazonaws.services.codedeploy.AmazonCodeDeployClient;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.agent.*;
@@ -113,11 +114,12 @@ public class CodeDeployRunner implements AgentBuildRunner {
                   Integer.parseInt(getWaitTimeOutSec(runnerParameters)),
                   getIntegerOrDefault(configParameters.get(WAIT_POLL_INTERVAL_SEC_CONFIG_PARAM), WAIT_POLL_INTERVAL_SEC_DEFAULT),
                   Boolean.parseBoolean(getRollbackOnFailure(runnerParameters)),
-                  Boolean.parseBoolean(getRollbackOnAlarmThreshold(runnerParameters)));
+                  Boolean.parseBoolean(getRollbackOnAlarmThreshold(runnerParameters)),
+                  getFileExistsBehavior(runnerParameters));
               } else {
                 awsClient.deployRevision(
                   s3BucketName, s3ObjectKey, bundleType, m.s3ObjectVersion, m.s3ObjectETag,
-                  applicationName, deploymentGroupName, getEC2Tags(runnerParameters), getAutoScalingGroups(runnerParameters), deploymentConfigName);
+                  applicationName, deploymentGroupName, getEC2Tags(runnerParameters), getAutoScalingGroups(runnerParameters), deploymentConfigName, getFileExistsBehavior(runnerParameters));
               }
             }
 
@@ -164,7 +166,7 @@ public class CodeDeployRunner implements AgentBuildRunner {
   }
 
   @NotNull
-  private AWSClient createAWSClient(@NotNull final AmazonS3Client s3Client, @NotNull final AmazonCodeDeployClient codeDeployClient, @NotNull final AgentRunningBuild runningBuild) {
+  private AWSClient createAWSClient(@NotNull final AmazonS3 s3Client, @NotNull final AmazonCodeDeployClient codeDeployClient, @NotNull final AgentRunningBuild runningBuild) {
     return new AWSClient(s3Client, codeDeployClient).withDescription("TeamCity build \"" + runningBuild.getBuildTypeName() + "\" #" + runningBuild.getBuildNumber());
   }
 

--- a/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployConstants.java
+++ b/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployConstants.java
@@ -68,7 +68,6 @@ public interface CodeDeployConstants {
   String APP_NAME_PARAM = "codedeploy.application.name";
   String APP_NAME_LABEL = "Application name";
 
-  String FILE_EXISTS_BEHAVIOR_PARAM_OLD = "codedeploy_file_exists_behavior";
   String FILE_EXISTS_BEHAVIOR_PARAM = "codedeploy.file.exists.behavior";
   String FILE_EXISTS_BEHAVIOR_LABEL = "Behavior when file exists";
 

--- a/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployConstants.java
+++ b/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployConstants.java
@@ -68,6 +68,10 @@ public interface CodeDeployConstants {
   String APP_NAME_PARAM = "codedeploy.application.name";
   String APP_NAME_LABEL = "Application name";
 
+  String FILE_EXISTS_BEHAVIOR_PARAM_OLD = "codedeploy_file_exists_behavior";
+  String FILE_EXISTS_BEHAVIOR_PARAM = "codedeploy.file.exists.behavior";
+  String FILE_EXISTS_BEHAVIOR_LABEL = "Behavior when file exists";
+
   String DEPLOYMENT_GROUP_NAME_PARAM_OLD = "codedeploy_deployment_group_name";
   String DEPLOYMENT_GROUP_NAME_PARAM = "codedeploy.deployment.group.name";
   String DEPLOYMENT_GROUP_NAME_LABEL = "Deployment group";

--- a/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployUtil.java
+++ b/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployUtil.java
@@ -181,6 +181,11 @@ final class CodeDeployUtil {
   }
 
   @Nullable
+  public static String getFileExistsBehavior(@NotNull Map<String, String> params) {
+    return getNewOrOld(params, FILE_EXISTS_BEHAVIOR_PARAM, FILE_EXISTS_BEHAVIOR_PARAM_OLD);
+  }
+
+  @Nullable
   public static String getAppName(@NotNull Map<String, String> params) {
     return getNewOrOld(params, APP_NAME_PARAM, APP_NAME_PARAM_OLD);
   }

--- a/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployUtil.java
+++ b/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/CodeDeployUtil.java
@@ -182,7 +182,7 @@ final class CodeDeployUtil {
 
   @Nullable
   public static String getFileExistsBehavior(@NotNull Map<String, String> params) {
-    return getNewOrOld(params, FILE_EXISTS_BEHAVIOR_PARAM, FILE_EXISTS_BEHAVIOR_PARAM_OLD);
+    return params.get(FILE_EXISTS_BEHAVIOR_PARAM);
   }
 
   @Nullable

--- a/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/ParametersValidator.java
+++ b/aws-codedeploy-common/src/main/java/jetbrains/buildServer/runner/codedeploy/ParametersValidator.java
@@ -23,6 +23,7 @@ import jetbrains.buildServer.util.amazon.AWSCommonParams;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +49,7 @@ final class ParametersValidator {
         invalids.put(REVISION_PATHS_PARAM, REVISION_PATHS_LABEL + " " + revisionPath + " doesn't exist");
       }
     }
+
 
     if (isDeploymentWaitEnabled(runnerParams)) {
       final String waitIntervalSec = configParams.get(WAIT_POLL_INTERVAL_SEC_CONFIG_PARAM);
@@ -135,6 +137,11 @@ final class ParametersValidator {
         invalids.put(DEPLOYMENT_GROUP_NAME_PARAM, DEPLOYMENT_GROUP_NAME_LABEL + " must not be empty");
       }
 
+      final String fileExistsParam = getFileExistsBehavior(runnerParams);
+      if (StringUtil.isNotEmpty(fileExistsParam)) {
+        validateFileExistsBehavior(invalids, fileExistsParam, FILE_EXISTS_BEHAVIOR_PARAM, FILE_EXISTS_BEHAVIOR_PARAM, runtime);
+      }
+
       if (isDeploymentWaitEnabled(runnerParams)) {
         final String waitTimeoutSec = getWaitTimeOutSec(runnerParams);
         if (StringUtil.isEmptyOrSpaces(waitTimeoutSec)) {
@@ -164,6 +171,15 @@ final class ParametersValidator {
     if (!isReference(param, runtime)) {
       if (!param.matches("[a-zA-Z_0-9!\\-\\.*'()/]*")) {
         invalids.put(key, name + " must contain only safe characters");
+      }
+    }
+  }
+
+  private static void validateFileExistsBehavior(@NotNull Map<String, String> invalids, @NotNull String param, @NotNull String key, @NotNull String name, boolean runtime) {
+    if (!isReference(param, runtime)) {
+      String[] allowedValues = {"DISALLOW", "OVERWRITE", "RETAIN"};
+      if (!Arrays.asList(allowedValues).contains(param)) {
+        invalids.put(key, name + " must contain either DISALLOW, OVERWRITE, or RETAIN");
       }
     }
   }

--- a/aws-codedeploy-server/src/main/resources/buildServerResources/editCodeDeployParams.jsp
+++ b/aws-codedeploy-server/src/main/resources/buildServerResources/editCodeDeployParams.jsp
@@ -125,6 +125,16 @@
     <td><props:checkboxProperty name="${rollback_on_alarm_param}" uncheckedValue="false"/></td>
 </tr>
 
+<tr class="groupingTitle" data-steps="${deploy_step}">
+    <td colspan="2">File Exists Behavior</td>
+</tr>
+<tr data-steps="${deploy_step}">
+    <th><label for="${file_exists_behavior_param}">${file_exists_behavior_label}: </label></th>
+    <td><props:textProperty name="${file_exists_behavior_param}" className="longField" maxlength="256"/>
+        <span class="smallNote">Use to set behavior when deployment finds a file that already exists, left blank will use default DISALLOW (OVERWRITE, RETAIN)</span><span class="error" id="error_${file_exists_behavior_param}"></span>
+    </td>
+</tr>
+
 <script type="application/javascript">
     window.codeDeployUpdateStepNote = function () {
         $j('#runnerParams .stepNote.facultativeNote').each(function() {

--- a/aws-codedeploy-server/src/main/resources/buildServerResources/editCodeDeployParams.jsp
+++ b/aws-codedeploy-server/src/main/resources/buildServerResources/editCodeDeployParams.jsp
@@ -128,10 +128,14 @@
 <tr class="groupingTitle" data-steps="${deploy_step}">
     <td colspan="2">File Exists Behavior</td>
 </tr>
+
 <tr data-steps="${deploy_step}">
     <th><label for="${file_exists_behavior_param}">${file_exists_behavior_label}: </label></th>
-    <td><props:textProperty name="${file_exists_behavior_param}" className="longField" maxlength="256"/>
-        <span class="smallNote">Use to set behavior when deployment finds a file that already exists, left blank will use default DISALLOW (OVERWRITE, RETAIN)</span><span class="error" id="error_${file_exists_behavior_param}"></span>
+    <td><props:selectProperty name="${file_exists_behavior_param}" className="mediumField">
+        <props:option value="">&lt;Default&gt;</props:option>
+        <props:option value="OVERWRITE">Overwrite</props:option>
+        <props:option value="RETAIN">Retain</props:option>
+    </props:selectProperty>
     </td>
 </tr>
 

--- a/aws-codedeploy-server/src/main/resources/buildServerResources/paramsConstants.jspf
+++ b/aws-codedeploy-server/src/main/resources/buildServerResources/paramsConstants.jspf
@@ -132,3 +132,6 @@
 
 <c:set var="green_fleet_param" value="<%=CodeDeployConstants.GREEN_FLEET_PARAM%>"/>
 <c:set var="green_fleet_label" value="<%=CodeDeployConstants.GREEN_FLEET_LABEL%>"/>
+
+<c:set var="file_exists_behavior_param" value="<%=CodeDeployConstants.FILE_EXISTS_BEHAVIOR_PARAM%>"/>
+<c:set var="file_exists_behavior_label" value="<%=CodeDeployConstants.FILE_EXISTS_BEHAVIOR_LABEL%>"/>

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext.teamcityDir = hasProperty('teamcity.dir') ? property('teamcity.dir') : "$roo
 ext.teamcityDataDir = "$rootDir/teamcity/data/" + teamcityVersion
 ext.teamcityJavaHome = System.properties['java.home']
 
-ext.amazonUtilVersion = hasProperty('amazon.util.version') ? property('amazon.util.version') : '3'
+ext.amazonUtilVersion = hasProperty('amazon.util.version') ? property('amazon.util.version') : '30'
 
 apply plugin: 'idea'
 idea {


### PR DESCRIPTION
Hey Crew,

The team I work with has been evaluating TeamCity for deployments w/ CodeDeploy plugin. We ran into some trouble with specifying the file exists behavior. I made a few changes to try and squeeze that in. 

Brought in a newer release of the amazon-utils so that I can pull in a newer version of the aws-java-sdk. There were some small changes to be made to support that with the s3 client, but this PR is primarily to support a way for users to specify their file behavior when it already exists. I pushed it onto the bottom of the configuration page, but it can be moved wherever that is appropriate. There is some validation to ensure that you are entering in one of the correct values, but beyond that it is pretty simple and straight forward. 

I'm pretty new, so any constructive feedback on the additional feature or code would be welcome. 

Thanks for your time,
Jon