### PR TITLE
Allow empty url in custom AWS Environment

### DIFF
--- a/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
+++ b/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
@@ -128,10 +128,12 @@ public final class AWSCommonParams {
 
     if (ENVIRONMENT_TYPE_CUSTOM.equals(params.get(ENVIRONMENT_NAME_PARAM))) {
       final String serviceEndpoint = params.get(SERVICE_ENDPOINT_PARAM);
-      try {
-        new URL(serviceEndpoint);
-      } catch (MalformedURLException e) {
-        invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
+      if (StringUtil.isNotEmpty(serviceEndpoint)) {
+        try {
+          new URL(serviceEndpoint);
+        } catch (MalformedURLException e) {
+          invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
+        }
       }
     }
 

--- a/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
+++ b/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
@@ -128,14 +128,10 @@ public final class AWSCommonParams {
 
     if (ENVIRONMENT_TYPE_CUSTOM.equals(params.get(ENVIRONMENT_NAME_PARAM))) {
       final String serviceEndpoint = params.get(SERVICE_ENDPOINT_PARAM);
-      if (StringUtil.isEmptyOrSpaces(serviceEndpoint)) {
-        invalids.put(SERVICE_ENDPOINT_PARAM, SERVICE_ENDPOINT_LABEL + " must not be empty");
-      } else {
-        try {
-          new URL(serviceEndpoint);
-        } catch (MalformedURLException e) {
-          invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
-        }
+      try {
+        new URL(serviceEndpoint);
+      } catch (MalformedURLException e) {
+        invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
       }
     }
 

--- a/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
+++ b/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
@@ -30,7 +30,6 @@
                     <td>
                         <props:textProperty name="${service_endpoint_param}" className="longField"/>
                         <span class="smallNote">Specify the URL for AWS service</span>
-                        <span class="error" id="error_${service_endpoint_param}"></span>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Hello Crew, 

Back again, I would like the custom AWS Environment variable 'Endpoint URL' to allow me to leave it blank. The code seems to have some redundancy around this. 

This exists, and would seemingly work fine if it were left empty https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#withRegion-java.lang.String- : 
```
   if (StringUtil.isNotEmpty(myServiceEndpoint)) {
      builder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(myServiceEndpoint, myRegion));
    } else {
      builder.withRegion(myRegion);
    }
```
But then we also don't allow it to be empty in the first place. 
```
    if (ENVIRONMENT_TYPE_CUSTOM.equals(params.get(ENVIRONMENT_NAME_PARAM))) {
      final String serviceEndpoint = params.get(SERVICE_ENDPOINT_PARAM);
      if (StringUtil.isEmptyOrSpaces(serviceEndpoint)) {
        invalids.put(SERVICE_ENDPOINT_PARAM, SERVICE_ENDPOINT_LABEL + " must not be empty");
      } else {
        try {
          new URL(serviceEndpoint);
        } catch (MalformedURLException e) {
          invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
        }
      }
    }
```
We could just remove the empty check and people won't be forced to manually enter the endpoint. There could be some additional clarity as to what the service endpoint is referring to as well. Should still validate for good URL formatting, and if it's left blank should use just the region, which should work.


Thanks for the consideration, welcome any constructive talks. I think this would help reduce forced manual effort on standard regions. 

Jon