### PR TITLE
Allow empty service endpoint, use default region endpoint. 

### DIFF
--- a/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
+++ b/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
@@ -128,10 +128,12 @@ public final class AWSCommonParams {
 
     if (ENVIRONMENT_TYPE_CUSTOM.equals(params.get(ENVIRONMENT_NAME_PARAM))) {
       final String serviceEndpoint = params.get(SERVICE_ENDPOINT_PARAM);
-      try {
-        new URL(serviceEndpoint);
-      } catch (MalformedURLException e) {
-        invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
+      if (StringUtil.isNotEmpty(serviceEndpoint)) {
+        try {
+          new URL(serviceEndpoint);
+        } catch (MalformedURLException e) {
+          invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
+        }
       }
     }
 

--- a/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
+++ b/amazon-util/src/main/java/jetbrains/buildServer/util/amazon/AWSCommonParams.java
@@ -128,14 +128,10 @@ public final class AWSCommonParams {
 
     if (ENVIRONMENT_TYPE_CUSTOM.equals(params.get(ENVIRONMENT_NAME_PARAM))) {
       final String serviceEndpoint = params.get(SERVICE_ENDPOINT_PARAM);
-      if (StringUtil.isEmptyOrSpaces(serviceEndpoint)) {
-        invalids.put(SERVICE_ENDPOINT_PARAM, SERVICE_ENDPOINT_LABEL + " must not be empty");
-      } else {
-        try {
-          new URL(serviceEndpoint);
-        } catch (MalformedURLException e) {
-          invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
-        }
+      try {
+        new URL(serviceEndpoint);
+      } catch (MalformedURLException e) {
+        invalids.put(SERVICE_ENDPOINT_PARAM, "Invalid URL format for " + SERVICE_ENDPOINT_LABEL);
       }
     }
 

--- a/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
+++ b/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
@@ -30,7 +30,6 @@
                     <td>
                         <props:textProperty name="${service_endpoint_param}" className="longField"/>
                         <span class="smallNote">Specify the URL for AWS service</span>
-                        <span class="error" id="error_${service_endpoint_param}"></span>
                     </td>
                 </tr>
                 <tr>

--- a/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
+++ b/amazon-util/src/main/resources/buildServerResources/editAWSCommonParams.jsp
@@ -26,10 +26,11 @@
             <props:selectSectionPropertyContent value="" caption="<Default>" />
             <props:selectSectionPropertyContent value="${environment_type_custom}" caption="Custom">
                 <tr>
-                    <th><label for="${service_endpoint_param}">${service_endpoint_label}: <l:star/></label></th>
+                    <th><label for="${service_endpoint_param}">${service_endpoint_label}: </label></th>
                     <td>
                         <props:textProperty name="${service_endpoint_param}" className="longField"/>
                         <span class="smallNote">Specify the URL for AWS service</span>
+                        <span class="error" id="error_${service_endpoint_param}"></span>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
(Second attempt at this one)
Hey Crew, 

Back again with another small change suggestion. While we were testing the plugin to first deploy to multiple regions at the same time, we also wanted to have the choice for us to deploy to a particular region. It would be nice if we could do this without having to parameterize the region AND the service endpoint, or make another configuration. 

The code already determines if the service endpoint is not empty when it is looking to build the client, and it should work just fine with region alone. 
```    
 if (StringUtil.isNotEmpty(myServiceEndpoint)) {
      builder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(myServiceEndpoint, myRegion));
    } else {
      builder.withRegion(myRegion);
    }
```

If there are concerns about making this optional, I would love to hear that feedback. Thanks for your time. 

Jon